### PR TITLE
fix(options_controller): OPTIONS request for PUT bounced

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,1 @@
+Rui AVELINO <rui.avelino@gmail.com>

--- a/src/Provider/Cors/OptionsController.php
+++ b/src/Provider/Cors/OptionsController.php
@@ -39,7 +39,9 @@ class OptionsController
     public function __invoke()
     {
         return Response::create('', 204, [
-            'Allow' => implode(',', $this->methods)
+            'Allow' => implode(',', $this->methods),
+            'Access-Control-Allow-Methods'=> implode(',', $this->methods),
+            'Access-Control-Allow-Origin' => '*'
         ]);
     }
 }

--- a/tests/Provider/Cors/OptionsControllerTest.php
+++ b/tests/Provider/Cors/OptionsControllerTest.php
@@ -25,6 +25,8 @@ class OptionsControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertTrue($response->headers->has('Allow'));
         $this->assertEquals('GET,POST', $response->headers->get('Allow'));
+        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('GET,POST', $response->headers->get('Access-Control-Allow-Methods'));
         $this->assertEquals(204, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
Put, and maybe others REST methods, was bounced by browser. Adding Access-Control-Allow-Methods in the Preflight Response